### PR TITLE
Wordpress用MDDFEEDプラグインを更新

### DIFF
--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -44,14 +44,18 @@ do_action( 'rss_tag_pre', 'rss2' );
 
 <channel>
   <title><?php wp_title_rss(); ?></title>
-  <atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
-  <link><?php bloginfo_rss('url') ?></link>
   <description><?php bloginfo_rss("description") ?></description>
+  <link><?php bloginfo_rss('url') ?></link>
+  <atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
+  <language><?php bloginfo_rss( 'language' ); ?></language>
+  <image>
+    <link><?php self_link(); ?></link>
+    <url><?php self_link(); ?>/images/head_logo.png</url>
+  </image>
   <lastBuildDate><?php
     $date = get_lastpostmodified( 'GMT' );
     echo $date ? mysql2date( 'r', $date, false ) : date( 'r' );
   ?></lastBuildDate>
-  <language><?php bloginfo_rss( 'language' ); ?></language>
   <sy:updatePeriod><?php
     $duration = 'hourly';
 

--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -96,14 +96,11 @@ do_action( 'rss_tag_pre', 'rss2' );
   <item>
     <title><?php the_title_rss() ?></title>
     <link><?php the_permalink_rss() ?></link>
-    <pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
-    <dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>
-    <?php the_category_rss('rss2') ?>
-
     <guid isPermaLink="false"><?php the_guid(); ?></guid>
 <?php if (get_option('rss_use_excerpt')) : ?>
     <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
 <?php else : ?>
+    <pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
     <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
   <?php $content = get_the_content_feed('rss2'); ?>
   <?php if ( strlen( $content ) > 0 ) : ?>
@@ -112,6 +109,8 @@ do_action( 'rss_tag_pre', 'rss2' );
     <content:encoded><![CDATA[<?php the_excerpt_rss(); ?>]]></content:encoded>
   <?php endif; ?>
 <?php endif; ?>
+<?php the_category_rss('rss2') ?>
+    <dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>
 <?php rss_enclosure(); ?>
   <?php
   /**

--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -30,6 +30,7 @@ do_action( 'rss_tag_pre', 'rss2' );
 	xmlns:atom="http://www.w3.org/2005/Atom"
 	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
 	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	xmlns:media="http://search.yahoo.com/mrss/" 
 	xmlns:mdd="http://mkdd.net/rss/1.0"
 	<?php
 	/**

--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -96,9 +96,6 @@ do_action( 'rss_tag_pre', 'rss2' );
   <item>
     <title><?php the_title_rss() ?></title>
     <link><?php the_permalink_rss() ?></link>
-<?php if ( get_comments_number() || comments_open() ) : ?>
-    <comments><?php comments_link_feed(); ?></comments>
-<?php endif; ?>
     <pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
     <dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>
     <?php the_category_rss('rss2') ?>
@@ -114,10 +111,6 @@ do_action( 'rss_tag_pre', 'rss2' );
   <?php else : ?>
     <content:encoded><![CDATA[<?php the_excerpt_rss(); ?>]]></content:encoded>
   <?php endif; ?>
-<?php endif; ?>
-<?php if ( get_comments_number() || comments_open() ) : ?>
-    <wfw:commentRss><?php echo esc_url( get_post_comments_feed_link(null, 'rss2') ); ?></wfw:commentRss>
-    <slash:comments><?php echo get_comments_number(); ?></slash:comments>
 <?php endif; ?>
 <?php rss_enclosure(); ?>
   <?php

--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -97,17 +97,13 @@ do_action( 'rss_tag_pre', 'rss2' );
     <title><?php the_title_rss() ?></title>
     <link><?php the_permalink_rss() ?></link>
     <guid isPermaLink="false"><?php the_guid(); ?></guid>
-<?php if (get_option('rss_use_excerpt')) : ?>
-    <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
-<?php else : ?>
     <pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
     <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
   <?php $content = get_the_content_feed('rss2'); ?>
-  <?php if ( strlen( $content ) > 0 ) : ?>
+<?php if ( strlen( $content ) > 0 ) : ?>
     <content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
-  <?php else : ?>
+<?php else : ?>
     <content:encoded><![CDATA[<?php the_excerpt_rss(); ?>]]></content:encoded>
-  <?php endif; ?>
 <?php endif; ?>
 <?php the_category_rss('rss2') ?>
     <dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>

--- a/mddfeed/feed-template.php
+++ b/mddfeed/feed-template.php
@@ -24,112 +24,112 @@ echo '<?xml version="1.0" encoding="'.get_option('blog_charset').'"?'.'>';
 do_action( 'rss_tag_pre', 'rss2' );
 ?>
 <rss version="2.0"
-	xmlns:content="http://purl.org/rss/1.0/modules/content/"
-	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
-	xmlns:dc="http://purl.org/dc/elements/1.1/"
-	xmlns:atom="http://www.w3.org/2005/Atom"
-	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
-	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
-	xmlns:media="http://search.yahoo.com/mrss/" 
-	xmlns:mdd="http://mkdd.net/rss/1.0"
-	<?php
-	/**
-	 * Fires at the end of the RSS root to add namespaces.
-	 *
-	 * @since 2.0.0
-	 */
-	do_action( 'rss2_ns' );
-	?>
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+  xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+  xmlns:media="http://search.yahoo.com/mrss/" 
+  xmlns:mdd="http://mkdd.net/rss/1.0"
+  <?php
+  /**
+   * Fires at the end of the RSS root to add namespaces.
+   *
+   * @since 2.0.0
+   */
+  do_action( 'rss2_ns' );
+  ?>
 >
 
 <channel>
-	<title><?php wp_title_rss(); ?></title>
-	<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
-	<link><?php bloginfo_rss('url') ?></link>
-	<description><?php bloginfo_rss("description") ?></description>
-	<lastBuildDate><?php
-		$date = get_lastpostmodified( 'GMT' );
-		echo $date ? mysql2date( 'r', $date, false ) : date( 'r' );
-	?></lastBuildDate>
-	<language><?php bloginfo_rss( 'language' ); ?></language>
-	<sy:updatePeriod><?php
-		$duration = 'hourly';
+  <title><?php wp_title_rss(); ?></title>
+  <atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
+  <link><?php bloginfo_rss('url') ?></link>
+  <description><?php bloginfo_rss("description") ?></description>
+  <lastBuildDate><?php
+    $date = get_lastpostmodified( 'GMT' );
+    echo $date ? mysql2date( 'r', $date, false ) : date( 'r' );
+  ?></lastBuildDate>
+  <language><?php bloginfo_rss( 'language' ); ?></language>
+  <sy:updatePeriod><?php
+    $duration = 'hourly';
 
-		/**
-		 * Filters how often to update the RSS feed.
-		 *
-		 * @since 2.1.0
-		 *
-		 * @param string $duration The update period. Accepts 'hourly', 'daily', 'weekly', 'monthly',
-		 *                         'yearly'. Default 'hourly'.
-		 */
-		echo apply_filters( 'rss_update_period', $duration );
-	?></sy:updatePeriod>
-	<sy:updateFrequency><?php
-		$frequency = '1';
+    /**
+     * Filters how often to update the RSS feed.
+     *
+     * @since 2.1.0
+     *
+     * @param string $duration The update period. Accepts 'hourly', 'daily', 'weekly', 'monthly',
+     *                         'yearly'. Default 'hourly'.
+     */
+    echo apply_filters( 'rss_update_period', $duration );
+  ?></sy:updatePeriod>
+  <sy:updateFrequency><?php
+    $frequency = '1';
 
-		/**
-		 * Filters the RSS update frequency.
-		 *
-		 * @since 2.1.0
-		 *
-		 * @param string $frequency An integer passed as a string representing the frequency
-		 *                          of RSS updates within the update period. Default '1'.
-		 */
-		echo apply_filters( 'rss_update_frequency', $frequency );
-	?></sy:updateFrequency>
-	<?php
-	/**
-	 * Fires at the end of the RSS2 Feed Header.
-	 *
-	 * @since 2.0.0
-	 */
-	do_action( 'rss2_head');
+    /**
+     * Filters the RSS update frequency.
+     *
+     * @since 2.1.0
+     *
+     * @param string $frequency An integer passed as a string representing the frequency
+     *                          of RSS updates within the update period. Default '1'.
+     */
+    echo apply_filters( 'rss_update_frequency', $frequency );
+  ?></sy:updateFrequency>
+  <?php
+  /**
+   * Fires at the end of the RSS2 Feed Header.
+   *
+   * @since 2.0.0
+   */
+  do_action( 'rss2_head');
 
-	while( have_posts()) : the_post();
+  while( have_posts()) : the_post();
 
-	$post_name = get_post_field( 'post_name', get_the_ID() );
-	if ( substr( $post_name, 0, 9 ) === "__trashed" ) {
-		continue; 
-	}
-	?>
-	<item>
-		<title><?php the_title_rss() ?></title>
-		<link><?php the_permalink_rss() ?></link>
+  $post_name = get_post_field( 'post_name', get_the_ID() );
+  if ( substr( $post_name, 0, 9 ) === "__trashed" ) {
+    continue; 
+  }
+  ?>
+  <item>
+    <title><?php the_title_rss() ?></title>
+    <link><?php the_permalink_rss() ?></link>
 <?php if ( get_comments_number() || comments_open() ) : ?>
-		<comments><?php comments_link_feed(); ?></comments>
+    <comments><?php comments_link_feed(); ?></comments>
 <?php endif; ?>
-		<pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
-		<dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>
-		<?php the_category_rss('rss2') ?>
+    <pubDate><?php echo mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false); ?></pubDate>
+    <dc:creator><![CDATA[<?php the_author() ?>]]></dc:creator>
+    <?php the_category_rss('rss2') ?>
 
-		<guid isPermaLink="false"><?php the_guid(); ?></guid>
+    <guid isPermaLink="false"><?php the_guid(); ?></guid>
 <?php if (get_option('rss_use_excerpt')) : ?>
-		<description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
+    <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
 <?php else : ?>
-		<description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
-	<?php $content = get_the_content_feed('rss2'); ?>
-	<?php if ( strlen( $content ) > 0 ) : ?>
-		<content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
-	<?php else : ?>
-		<content:encoded><![CDATA[<?php the_excerpt_rss(); ?>]]></content:encoded>
-	<?php endif; ?>
+    <description><![CDATA[<?php the_excerpt_rss(); ?>]]></description>
+  <?php $content = get_the_content_feed('rss2'); ?>
+  <?php if ( strlen( $content ) > 0 ) : ?>
+    <content:encoded><![CDATA[<?php echo $content; ?>]]></content:encoded>
+  <?php else : ?>
+    <content:encoded><![CDATA[<?php the_excerpt_rss(); ?>]]></content:encoded>
+  <?php endif; ?>
 <?php endif; ?>
 <?php if ( get_comments_number() || comments_open() ) : ?>
-		<wfw:commentRss><?php echo esc_url( get_post_comments_feed_link(null, 'rss2') ); ?></wfw:commentRss>
-		<slash:comments><?php echo get_comments_number(); ?></slash:comments>
+    <wfw:commentRss><?php echo esc_url( get_post_comments_feed_link(null, 'rss2') ); ?></wfw:commentRss>
+    <slash:comments><?php echo get_comments_number(); ?></slash:comments>
 <?php endif; ?>
 <?php rss_enclosure(); ?>
-	<?php
-	/**
-	 * Fires at the end of each RSS2 feed item.
-	 *
-	 * @since 2.0.0
-	 */
-	do_action( 'rss2_item' );
-	?>
-		<mdd:status><?php echo (get_post_status()=='publish') ? 'Usable' : 'Canceled';?></mdd:status>
-	</item>
-	<?php endwhile; ?>
+  <?php
+  /**
+   * Fires at the end of each RSS2 feed item.
+   *
+   * @since 2.0.0
+   */
+  do_action( 'rss2_item' );
+  ?>
+    <mdd:status><?php echo (get_post_status()=='publish') ? 'Usable' : 'Canceled';?></mdd:status>
+  </item>
+  <?php endwhile; ?>
 </channel>
 </rss>


### PR DESCRIPTION
## 更新内容
- 従来のプラグインではそのままインストールしても
https://minkabu.jp/mdd/mdd-news-ja.html#validate-news-api
に記述されたValidateAPIでtrueにならなかったので
trueが返ってくるように改修した
- tabが入って見難かったので半角スペース2個に置換した

## 確認方法
- http://mddfeed.kinsta.cloud/?feed=mdd
プラグインを入れた上記RSSを
`curl -X POST -F file=@sample.rss https://mkdd.net/api/v1/validate_news`
に渡して true が返ってくる事を確認する

https://github.com/minkabu/mkdd/issues/627